### PR TITLE
Fix issue with reflection

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -85,7 +85,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 			log.Debugln(filteredRoute.GetURL())
 			log.Debugln(reflect.ValueOf(filteredRoute.GetController()))
 			log.Debugln("Controller type o:: ", mapControllerNameToControllerObj[filteredRoute.GetController()])
-			reflect.ValueOf(mapControllerNameToControllerObj[filteredRoute.GetController()]).MethodByName(filteredRoute.GetMethod()).Call([]reflect.Value{})
+			mapControllerNameToControllerObj[filteredRoute.GetController()].MethodByName(filteredRoute.GetMethod()).Call([]reflect.Value{})
 		}
 	}
 }


### PR DESCRIPTION
Avoided using reflect.ValueOf on map that returns the reflect.Value.
It would the error while getting the object.