### PR TITLE
Add functionality for response rendering.

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -11,7 +11,6 @@ import (
 )
 
 func init() {
-	// cmdRun.Flags().StringVarP(&AppDirName, "dir", "d", "", "Directory under which app needs to be run.")
 	CmdApp.AddCommand(cmdRun)
 }
 
@@ -33,20 +32,17 @@ func runApp(cmd *cobra.Command, args []string) {
 	// server.ScanAppsForControllers(AppName)
 	// log.Debug("Run the server")
 	//gokul.Run(server)
-	fmt.Println("hi there " + filepath.Join(AppDirName, "src", "github.com", AppName, "variables.env"))
+	log.Debugln("Location of variable.env is ::  {}", filepath.Join(AppDirName, "src", "github.com", AppName, "variables.env"))
 	// command := exec.Command("bash", "-c", "source", filepath.Join(AppDirName, "src", "github.com", AppName, "variables.env"))
 	goPath, err := exec.LookPath("go")
 	if err != nil {
 		log.Fatalln("Error while getting the path of the go binary", err)
 	}
-	log.Debug("The gopath is ", goPath)
+	log.Debug("The gopath is :: ", goPath)
 	command := exec.Command(goPath, "run", filepath.Join(AppDirName, "src", "github.com", AppName, "main.go"))
 	stdOutReader, errors := command.StdoutPipe()
-	// command.Env = append(os.Environ(),
-	// 	"GOPATH=$GOPATH:"+AppDirName,
-	// )
 	done := make(chan struct{})
-
+	log.Debugln("Running the main.go of app :: ", AppName)
 	scanner := bufio.NewScanner(stdOutReader)
 	go func() {
 		for scanner.Scan() {

--- a/server/appTemplates/apptemplates.go
+++ b/server/appTemplates/apptemplates.go
@@ -731,7 +731,7 @@ func writeToFile(dirName, fileName, appName, cfgFileLocation, content string) {
 	outputFile, outputError := os.Create(filepath.Join(dirName, fileName))
 
 	if outputError != nil {
-		log.Fatalln("An error occurred with file creation\n")
+		log.Fatalln("An error occurred with file creation")
 		panic(outputError)
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -12,56 +12,20 @@ import (
 )
 
 var (
-	// regex         *regexp.Regexp
-	// regexToIgnore *regexp.Regexp
-	// pattern             = "[\\w.]+\\s+=\\s+[\\w]+"
-	// patternToIgnoreLine = "^#+.*"
 	Cfg map[string]string
 )
 
 func init() {
-	// regex, _ = regexp.Compile(pattern)
-	// regexToIgnore, _ = regexp.Compile(patternToIgnoreLine)
-	// Output to stdout instead of the default stderr, could also be a file.
 	log.SetOutput(os.Stdout)
 	// Only log the debug severity or above.
 	log.SetLevel(log.DebugLevel)
 }
 
-// Load the config file for the server
-//
+// LoadConfigFile ... Load the config file for the server
 func LoadConfigFile(cfgFile string) {
 	log.Debugln("Input to LoadConfigFile function is :: ", cfgFile)
 	serverConfig := loadConfig(cfgFile)
 
-	// srcRoot, _ := os.Getwd()
-
-	// log.Debugln("srcRoot is ", srcRoot)
-	// srcRoot = filepath.Join(srcRoot, "src/", gokul.GOKUL_SRC_ROOT, "/")
-	// log.Debugln("srcRoot is where we want to be :: ", srcRoot)
-	// //inputFile, inputError := os.Open(srcRoot + "/" + cfgFile)
-	// inputFile, inputError := os.Open("server.cfg")
-
-	// if inputError != nil {
-	// 	log.Fatal("Error reading the config file for server. Exiting.", inputError)
-	// 	os.Exit(1)
-	// }
-	// defer inputFile.Close()
-	// inputReader := bufio.NewReader(inputFile)
-	// for {
-	// 	inputString, readerError := inputReader.ReadString('\n')
-	// 	if regexToIgnore.MatchString(inputString) {
-	// 		continue
-	// 	} else if regex.MatchString(inputString) {
-	// 		pair := strings.Split(inputString, "=")
-	// 		if len(pair) == 2 {
-	// 			serverConfig[strings.TrimSpace(pair[0])] = strings.TrimSpace(pair[1])
-	// 		}
-	// 	}
-	// 	if readerError == io.EOF {
-	// 		break
-	// 	}
-	// }
 	if len(serverConfig) > 0 {
 		Cfg = serverConfig
 	}
@@ -73,7 +37,6 @@ func readConfig(filename, dirname string, defaults map[string]interface{}) (*vip
 		v.SetDefault(key, value)
 	}
 	v.SetConfigName(filename)
-	// v.AddConfigPath("./src/github.com/gokul/server/config")
 	v.AddConfigPath(dirname)
 	v.AutomaticEnv()
 	err := v.ReadInConfig()
@@ -103,13 +66,13 @@ func loadConfig(cfgFileName string) map[string]string {
 		"logging": map[string]interface{}{
 			"level": "debug",
 		},
-		"apps" : map[string]interface{}{
-			"directory" : "apps",
+		"apps": map[string]interface{}{
+			"directory": "apps",
 		},
 	})
 
 	if err != nil {
-		panic(fmt.Errorf("Error when reading config: %v\n", err))
+		panic(fmt.Errorf("Error when reading config %v ", err))
 	}
 	log.Debugln("Configuration is :: ", v1)
 

--- a/server/controller/baseController.go
+++ b/server/controller/baseController.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"fmt"
+	log "github.com/sirupsen/logrus"
 )
 
 type Controller interface {
@@ -10,10 +10,38 @@ type Controller interface {
 
 type BaseController struct {
 	Controller
+}
 
+type ModelAndView struct {
+	Model        interface{}
+	View         string
+	ResponseType string
+}
+
+func (modelAndView *ModelAndView) SetModel(model interface{}) {
+	modelAndView.Model = model
+}
+
+func (modelAndView *ModelAndView) SetView(view string) {
+	modelAndView.View = view
+}
+
+func (modelAndView *ModelAndView) SetResponseType(responseType string) {
+	modelAndView.ResponseType = responseType
+}
+
+func (modelAndView *ModelAndView) GetModel() interface{} {
+	return modelAndView.Model
+}
+
+func (modelAndView *ModelAndView) GetView() string {
+	return modelAndView.View
+}
+
+func (modelAndView *ModelAndView) GetResponseType() string {
+	return modelAndView.ResponseType
 }
 
 func (baseController *BaseController) Render() {
-	fmt.Println("Inside render method")
+	log.Debugln("Inside render method of BaseController...")
 }
-

--- a/server/routes/route.go
+++ b/server/routes/route.go
@@ -92,10 +92,9 @@ func GetRoute(url string, httpVerb string) (r *route) {
 			httpMethod := strings.TrimSpace(routeLine[0])
 			completeURL := strings.TrimSpace(routeLine[1])
 			controllerAndMethod := strings.TrimSpace(routeLine[2])
-			log.Info("HttpMethod %s :: completeURL %s :: controllerAndMethod :: %s\n", httpMethod, completeURL, controllerAndMethod)
+			log.Info("HttpMethod :: completeURL :: controllerAndMethod :: ", httpMethod, completeURL, controllerAndMethod)
 			if strings.Compare(appURL, completeURL) == 0 {
 				if strings.Compare(httpVerb, httpMethod) == 0 {
-					//r = new(route)
 					r.url = completeURL
 					r.method = strings.Split(controllerAndMethod, ".")[1]
 					r.controller = strings.Split(controllerAndMethod, ".")[0]

--- a/server/server.go
+++ b/server/server.go
@@ -1,12 +1,16 @@
 package server
 
 import (
-	"net/http"
-
+	"encoding/json"
+	"encoding/xml"
+	"html/template"
 	"net"
+	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -19,12 +23,12 @@ var (
 	httpServer                       *http.Server
 	baseControllers                  *controller.BaseController
 	mapControllerNameToControllerObj map[string]reflect.Value
+	tempServer                       *server
 )
 
 func init() {
 	// Output to stdout instead of the default stderr, could also be a file.
 	log.SetOutput(os.Stdout)
-
 	// Only log the debug severity or above.
 	log.SetLevel(log.DebugLevel)
 	baseControllers = new(controller.BaseController)
@@ -38,24 +42,27 @@ func (s *server) GetConfig() map[string]string {
 	return s.cfg
 }
 
-// Creates the new server
+//NewServer ... Creates the new server
 func NewServer(cfgFileLocation string, mapOfControllerNameToControllerObj map[string]reflect.Value) *server {
 	log.Debugln("Entering the NewServer constructor.")
 	if len(cfgFileLocation) > 0 {
 		config.LoadConfigFile(cfgFileLocation)
 	}
 	mapControllerNameToControllerObj = mapOfControllerNameToControllerObj
-	return &server{cfg: config.Cfg}
+	tempServer = &server{cfg: config.Cfg}
+	return tempServer
 }
 
 // This method handles all requests.
 func handle(w http.ResponseWriter, r *http.Request) {
-	log.Debug("Inside the handle method for the request")
+	log.Debugln("Inside the handle method for the request")
+	log.Debugln("Accept header in the request is :: ", r.Header["Accept"][0])
+	var requestAcceptHeader = r.Header["Accept"][0]
 	var maxRequestSize int64
 	var err error
 
 	if maxRequestSize, err = strconv.ParseInt(config.Cfg["http.maxrequestsize"], 10, 64); err != nil {
-		log.Fatalln("Error parsing the maxrequestsize . Exiting")
+		log.Fatalln("Error parsing the maxrequestsize. Exiting...")
 		os.Exit(1)
 	}
 
@@ -67,27 +74,92 @@ func handle(w http.ResponseWriter, r *http.Request) {
 
 	if r.URL.Path != "/favicon.ico" {
 		if filteredRoute := routes.GetRoute(r.URL.Path, r.Method); filteredRoute != nil {
-			log.Debugln("Filtered route is %v\n", *filteredRoute)
-			//path := strings.Split(r.URL.Path, "/")
+			log.Debugln("Filtered route is ", *filteredRoute)
 			log.Debugln(filteredRoute.GetController())
 			log.Debugln(filteredRoute.GetMethod())
 			log.Debugln(filteredRoute.GetURL())
 			log.Debugln(reflect.ValueOf(filteredRoute.GetController()))
-			log.Debugln("Controller type o:: ", mapControllerNameToControllerObj[filteredRoute.GetController()])
+			log.Debugln("Controller type object :: ", mapControllerNameToControllerObj[filteredRoute.GetController()])
+			log.Debugln("About to execute the controller method using the reflection...")
 			response := mapControllerNameToControllerObj[filteredRoute.GetController()].MethodByName(filteredRoute.GetMethod()).Call([]reflect.Value{})
-			log.Debugln("Response is %v", response)
+
+			if response != nil && len(response) != 2 {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("500 - Controller Method is returning more than 2 parameters."))
+			}
+
+			if response[1].Elem().Interface() == nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("500 - Nil ModelAndView Struct"))
+			}
+
+			log.Debugln("First Arg Type name is :: ", response[0].Type().Name())
+			log.Debugln("Second Arg Type name is ::", response[1].Elem().Type().Name())
+
+			if response[0].Type().Name() != "error" {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("500 - Controller Method should return first parameter as error interface."))
+			}
+
+			if response[1].Elem().Type().Name() != "ModelAndView" {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("500 - Controller Method should return second parameter as ModelAndView struct."))
+			}
+			modelAndView := response[1].Elem().Interface().(controller.ModelAndView)
+			log.Debugln("Value of ModelAndView struct received is :: ", modelAndView)
+			model := modelAndView.GetModel()
+			view := modelAndView.GetView()
+			responseType := modelAndView.GetResponseType()
+
+			log.Debugln("Model to be passed to template is :: ", model)
+			log.Debugln("View to be passed to template is :: ", view)
+			log.Debugln("ResponseType of the response is :: ", responseType)
+
+			if r.Header["Accept"] != nil && len(r.Header["Accept"]) != 0 && (strings.Contains(requestAcceptHeader, "*/*") || strings.Contains(requestAcceptHeader, "text/html") && strings.Contains(requestAcceptHeader, responseType)) && len(view) != 0 {
+				w.Header().Set("Content-Type", responseType)
+				templateFileName := filepath.Join(tempServer.GetConfig()["apps.directory"], "view", view+".html")
+				tmpl := template.Must(template.ParseFiles(templateFileName))
+				tmpl.Execute(w, model)
+				defer recoverFromTemplateExecute()
+			} else if strings.Contains(requestAcceptHeader, "application/json") && strings.Contains(requestAcceptHeader, responseType) {
+				w.Header().Set("Content-Type", responseType)
+				jsonEncoder := json.NewEncoder(w)
+				jsonEncoder.SetEscapeHTML(true)
+				if err := jsonEncoder.Encode(model); err != nil {
+					log.Errorln("Error while marshalling json response for the request", filteredRoute.GetURL())
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(err.Error()))
+				}
+			} else if strings.Contains(requestAcceptHeader, "application/xml") && strings.Contains(requestAcceptHeader, responseType) {
+				w.Header().Set("Content-Type", responseType)
+				xmlEncoder := xml.NewEncoder(w)
+				if err := xmlEncoder.Encode(model); err != nil {
+					log.Errorln("Error while marshalling xml response for the request", filteredRoute.GetURL())
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(err.Error()))
+				}
+			}
+
 		}
+
 	}
 }
 
+// Run ... Runs the server
 func Run(s *server) {
+	log.Debugln("Entering the Server's Run method.")
+
 	var readTimeOut int64
 	var writeTimeOut int64
 	var network string
 	var err error
 
+	//	templateFileLocation = filepath.Join(s.cfg["apps.directory"], "views")
 	address := s.cfg["server.address"] + ":" + s.cfg["server.port"]
 	network = "tcp"
+
+	log.Debugln("Read Timeout for the http connection for the service is :: ", config.Cfg["timeout.read"])
+	log.Debugln("Write Timeout for the http connection for the service is :: ", config.Cfg["timeout.write"])
 
 	if readTimeOut, err = strconv.ParseInt(config.Cfg["timeout.read"], 10, 64); err != nil {
 		log.Debugln("The value of readtimeout received is ", config.Cfg["timeout.read"])
@@ -96,6 +168,7 @@ func Run(s *server) {
 	}
 
 	if writeTimeOut, err = strconv.ParseInt(config.Cfg["timeout.write"], 10, 64); err != nil {
+		log.Debugln("The value of writetimeout received is ", config.Cfg["timeout.write"])
 		log.Fatalln("Error parsing the write timeout. Exiting...")
 		os.Exit(1)
 	}
@@ -110,9 +183,15 @@ func Run(s *server) {
 	listener, err := net.Listen(network, httpServer.Addr)
 
 	if err != nil {
-		log.Fatalln("Failed to listen:", err)
+		log.Fatalln("Failed to listen :: ", err)
 	}
 
-	log.Fatalln("Failed to serve:", httpServer.Serve(listener))
+	log.Fatalln("Failed to serve :: ", httpServer.Serve(listener))
+}
 
+func recoverFromTemplateExecute() {
+	log.Debugln("Entering the method recoverFromTemplateExecute while executing template.")
+	if err := recover(); err != nil {
+		log.Errorln("Error while executing template :: ", err)
+	}
 }


### PR DESCRIPTION
Added functionality to render response when Accept HTTP header is */*,
text/html, application/json and application/xml. It injects the
content-type header in response as per the response type set by Accept
Header. ModelAndView struct is created having 3 fields:
1. Model
2. View
3. ContentType of response

This would be the response of every controller which is inspected using
reflection when we call the controller method as per routes.cfg
 #Todo Convert routes.cfg to yaml file for more modern style of
 properties file.
Should try to resolve #14.