### PR TITLE
Update server dependencies during deploy.

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -63,7 +63,7 @@ func deployApp(cmd *cobra.Command, args []string) {
 		config.LoadConfigFile(CfgFileLocation)
 	}
 
-	executeOSCommand("go", "get", "-d", "github.com/vipulbhale/gokul/server")
+	executeOSCommand("go", "get", "-u", "-d", "github.com/vipulbhale/gokul/server")
 	// start scanning all controllers for the given app or apps directory
 	if len(AppName) != 0 {
 		goreflect.ScanAppsDirectory(config.Cfg, AppName)


### PR DESCRIPTION
app deploy -n 'appName' -d 'dir' command does deploy. As a part of this it fetches all packages required that is gokul server and its dependencies. It issues the command "go get -d github.com/vipulbhale/gokul/server. However because of lack of -u flag it doesn't update the existing packages. This is causing issues while doing manual testing. However this flag (-u) needs to be removed later on as it may impact the stability of server dependencies stack in production.
This should resolve #16 .