### PR TITLE
Fix the issue related to config for viper.

### DIFF
--- a/server/appTemplates/apptemplates.go
+++ b/server/appTemplates/apptemplates.go
@@ -183,10 +183,11 @@ func GetLogger() *logrus.Logger {
 }
 
 func initConfig() {
+	viper.Reset()
 	setupViper()
 	if err := viper.ReadInConfig(); err != nil {
 		fmt.Printf("Can't read config, %v. Creating a template configfile in current directory.\n", err)
-		cmdConfigContent := []byte("logging:\n  level: info\n  destination: ""\n")
+		cmdConfigContent := []byte("logging:\n  level: info\n  destination: \"\"\n")
 		err := ioutil.WriteFile("./application.yaml", cmdConfigContent, 0644)
 		if err != nil {
 			fmt.Println("Not able to create the config file in current directory. Exiting...", err)


### PR DESCRIPTION
1. Issue related to the viper picking up gokul config is hindering the
webapp picking up application.yaml and picking up gokul. So needs to
issue reset and try it.

2. Fix issue related to double quote escaping.
   Escape double quote in the apptemplate corresponding logger.go createed
for web app by gokul.