### PR TITLE
Fix issue related to content negotiation.

### DIFF
--- a/server/controller/baseController.go
+++ b/server/controller/baseController.go
@@ -16,9 +16,8 @@ type BaseController struct {
 }
 
 type ModelAndView struct {
-	Model        interface{}
-	View         string
-	ResponseType string
+	Model interface{}
+	View  string
 }
 
 func (modelAndView *ModelAndView) SetModel(model interface{}) {
@@ -29,20 +28,12 @@ func (modelAndView *ModelAndView) SetView(view string) {
 	modelAndView.View = view
 }
 
-func (modelAndView *ModelAndView) SetResponseType(responseType string) {
-	modelAndView.ResponseType = responseType
-}
-
 func (modelAndView *ModelAndView) GetModel() interface{} {
 	return modelAndView.Model
 }
 
 func (modelAndView *ModelAndView) GetView() string {
 	return modelAndView.View
-}
-
-func (modelAndView *ModelAndView) GetResponseType() string {
-	return modelAndView.ResponseType
 }
 
 func (baseController *BaseController) Render() {


### PR DESCRIPTION
Now added functionality to parse accept header using regex. Then sorted
it based on quality. Based on the topmost quality if content-type
corresponding to it existed and view's availability, then only corresponding  to it render the content. Else send http 406 for now. More functionality needs to be added more content-negotiation.
Also removed the compulsion on user to have content type getting included in the response.