### PR TITLE
Routes config for app using YAML

### DIFF
--- a/server/appTemplates/apptemplates.go
+++ b/server/appTemplates/apptemplates.go
@@ -37,6 +37,18 @@ const ROUTES_CFG_TEMPLATE = `GET             /demo           DemoController.Demo
 GET             /demoxml           DemoController.DemoXML
 GET             /demojson           DemoController.DemoJson
 `
+
+const ROUTES_YML_TEMPLATE = `uriInfo:
+      - uri: /demo
+        controller-method: "Democontroller.Demo"
+        http-method: GET
+      - uri: /demoxml
+        controller-method: "Democontroller.DemoXML"
+        http-method: GET
+      - uri: /demojson
+        controller-method: "Democontroller.DemoJson"
+        http-method: GET`
+
 const MAIN_PACKAGE = `package main
 import (
 	"fmt" 
@@ -280,11 +292,6 @@ func init() {
 func CreateTemplates(dirname, appName, cfgFileLocation string) {
 	log.Debugln("Entering the CreateTemplates method.")
 
-	// writeToFile(filepath.Join(dirname, "src", "github.com", appName, "routes"), "route.go", appName, cfgFileLocation, ROUTES_TEMPLATE)
-	// writeToFile(filepath.Join(dirname, "src", "github.com", appName, "server"), "server.go", appName, cfgFileLocation, SERVER_TEMPLATE)
-	// writeToFile(filepath.Join(dirname, "src", "github.com", appName, "config"), "config.go", appName, cfgFileLocation, SERVER_CONFIG_TEMPLATE)
-	// writeToFileReflect(filepath.Join(dirname, "src", "github.com", appName, "reflect", "reflect.go"), GOKUL_REFLECT_TEMPLATE)
-
 	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName), "main.go", appName, cfgFileLocation, MAIN_PACKAGE)
 	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "controller"), "controller.go", appName, cfgFileLocation, CONTROLLER_TEMPLATE)
 	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "service"), "service.go", appName, cfgFileLocation, SERVICE_TEMPLATE)
@@ -292,7 +299,7 @@ func CreateTemplates(dirname, appName, cfgFileLocation string) {
 	writeToFileContent(filepath.Join(dirname, "src", "github.com", appName, "view", "view.html"), VIEW_TEMPLATE)
 	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "util"), "logger.go", appName, cfgFileLocation, UTIL_LOGGER_TEMPLATE)
 	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "config"), "server.yml", appName, cfgFileLocation, CONFIG_FILE_TEMPLATE)
-	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "config"), "routes.cfg", appName, cfgFileLocation, ROUTES_CFG_TEMPLATE)
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "config"), "routes.yml", appName, cfgFileLocation, ROUTES_YML_TEMPLATE)
 	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName), "variables.env", appName, cfgFileLocation, "GOPATH="+os.Getenv("GOPATH"))
 
 	createBinAndPackageDirectory(filepath.Join(dirname, "bin"))

--- a/server/routes/route.go
+++ b/server/routes/route.go
@@ -37,10 +37,10 @@ type route struct {
 
 type routeYaml struct {
 	UriInfo []struct {
-		Uri              string
+		Uri              string `yaml:"uri"`
 		ControllerMethod string `yaml:"controller-method"`
 		HttpMethod       string `yaml:"http-method"`
-	}
+	} `yaml:"uriInfo"`
 }
 
 func (r *route) GetURL() string {
@@ -152,8 +152,8 @@ func getRouteWhenFileIsCfgType(appURL string, httpVerb string) (r *route) {
 			if strings.Compare(appURL, completeURL) == 0 {
 				if strings.Compare(httpVerb, httpMethod) == 0 {
 					r.Url = completeURL
-					r.Method = strings.Split(controllerAndMethod, ".")[1]
 					r.Controller = strings.Split(controllerAndMethod, ".")[0]
+					r.Method = strings.Split(controllerAndMethod, ".")[1]
 				}
 			}
 		}
@@ -175,9 +175,9 @@ func getRouteFromYaml(url string, httpVerb string) (r *route) {
 		log.Debugln("The route to be compared is :: ", routeForYaml.UriInfo[i])
 		if strings.Compare(strings.TrimSpace(url), routeForYaml.UriInfo[i].Uri) == 0 && strings.Compare(strings.ToLower(strings.TrimSpace(httpVerb)), strings.ToLower(routeForYaml.UriInfo[i].HttpMethod)) == 0 {
 			log.Debugln("There is match for url and httpverb")
-			r.SetController(routeForYaml.UriInfo[i].ControllerMethod)
-			r.SetMethod(routeForYaml.UriInfo[i].HttpMethod)
 			r.SetURL(routeForYaml.UriInfo[i].Uri)
+			r.SetController(strings.Split(routeForYaml.UriInfo[i].ControllerMethod, ".")[0])
+			r.SetMethod(strings.Split(routeForYaml.UriInfo[i].ControllerMethod, ".")[1])
 			log.Debugln("The selected route is ", r)
 			break
 		}
@@ -192,11 +192,13 @@ func readRoutesYaml() (routeForYaml *routeYaml) {
 	if err != nil {
 		log.Fatalln("Error while reading the app config file in yaml format. Please create the file in config directory of app. Exiting... ")
 	}
-	err = yaml.Unmarshal(yamlFile, &routeForYaml)
+	log.Debugln("The yaml file for routes is :: ", yamlFile)
+	routeParsed := routeYaml{}
+	err = yaml.Unmarshal(yamlFile, &routeParsed)
 	if err != nil {
 		log.Fatalln("Error while parsing the routes yaml file. Please try again with correct routes.yml file")
 	}
-	log.Debugln("Contents of parsed yaml file are :: ", routeForYaml)
-	return routeForYaml
+	log.Debugln("Contents of parsed yaml file are :: ", &routeParsed)
+	return &routeParsed
 
 }


### PR DESCRIPTION
This PR addresses:

For any app use the configuration related routing information in YAML format. With new subcommand it creates the sample routes.yml file that can referred by new app to create routes for the app. The earlier format of routing configuration is discouraged and now resorting to more of standard format like YAML. 