### PR TITLE
ISSUE#48 Change structure of generated proj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .vscode/
 go.sum
+gokul.yaml

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,19 @@ module github.com/vipulbhale/gokul
 go 1.14
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/mitchellh/mapstructure v1.2.2 // indirect
+	github.com/pelletier/go-toml v1.7.0 // indirect
 	github.com/sirupsen/logrus v1.5.0
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v0.0.7
-	github.com/spf13/viper v1.6.2
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/viper v1.6.3
+	golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/ini.v1 v1.55.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -31,11 +31,13 @@ func executeOSCommand(commandString string, parameters ...string) {
 	if err != nil {
 		Log.Fatalln("Error while getting the path of the go binary", err)
 	}
-	Log.Debug("The gopath is ", goPath)
+	Log.Debug("The path of go binary is ", goPath)
 
 	command := exec.Command(goPath, parameters...)
-	command.Env = []string{"GOPATH=" + filepath.Join(AppDirName), "PATH=" + os.Getenv("PATH")}
+	Log.Debugln("The AppDirName that would become GOPATH is ", AppDirName)
+	command.Env = []string{"GOPATH=" + os.Getenv("GOPATH"), "PATH=" + os.Getenv("PATH"), "HOME=" + os.Getenv("HOME"), "GOCACHE=" + os.Getenv("GOCACHE")}
 	stderr, err := command.StderrPipe()
+
 	if err != nil {
 		Log.Fatal(err)
 	}
@@ -58,11 +60,11 @@ func deployApp(cmd *cobra.Command, args []string) {
 	if len(CfgFileLocation) > 0 {
 		config.LoadConfigFile(CfgFileLocation)
 	} else {
-		CfgFileLocation = filepath.Join(AppDirName, "src", "github.com", AppName, "config", "server.yml")
+		CfgFileLocation = filepath.Join(AppDirName, "src", "github.com", AppName, "internal", "config", "server.yml")
 		config.LoadConfigFile(CfgFileLocation)
 	}
 
-	executeOSCommand("go", "get", "-u", "-d", "github.com/vipulbhale/gokul/server")
+	executeOSCommand("go", "get", "-u", "-d", "github.com/vipulbhale/gokul/pkg/server")
 	// start scanning all controllers for the given app or apps directory
 	if len(AppName) != 0 {
 		goreflect.ScanAppsDirectory(config.Cfg, AppName)

--- a/internal/new.go
+++ b/internal/new.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	appTemplates "github.com/vipulbhale/gokul/pkg/server/appTemplates"
+	"github.com/vipulbhale/gokul/pkg/server/apptempl"
 )
 
 var cmdNew = &cobra.Command{
@@ -23,36 +23,42 @@ func init() {
 func createNewApplication(cmd *cobra.Command, args []string) {
 	Log.Debugln("Inside the new application command")
 	Log.Debugln("Scanning all existing apps for controllers")
-	// First check AppDirName is provided
-	if len(AppDirName) == 0 {
-		panic("Application Directory is not provided")
-	}
+
 	//Add the directory to the goPath
 	//First check in GOPATH
-	if val := isPresentInGoPath(AppDirName); val {
+	if val := isPresentAndInGoPath(AppDirName); val {
 		Log.Debugln("Is AppDirName present in GOPATH", val)
 	} else {
 		Log.Debugln("Adding the AppsDirectory to GOPATH")
 		addToGoPath(AppDirName)
 		Log.Debugln("After making changes current GOPATH is ", os.Getenv("GOPATH"))
 	}
+
+		// // First check AppDirName is provided
+	if len(AppDirName) == 0 {
+		AppDirName = os.Getenv("GOPATH")
+	}
 	// all application/s are scanned now copy required server files to the apps directory
-	appTemplates.CreateTemplates(AppDirName, AppName, CfgFileLocation)
+	apptempl.CreateTemplates(AppDirName, AppName, CfgFileLocation)
 }
 
 /**
 Check whether the AppDirectory is present in the the GOPATH
 */
-func isPresentInGoPath(appdirname string) bool {
+func isPresentAndInGoPath(appDirName string) bool {
 	//check if present in GOPATH
 	gopath := os.Getenv("GOPATH")
 	Log.Debugln("Current GoPath is ", gopath)
-	if strings.Contains(gopath, appdirname) {
+	if strings.Contains(gopath, appDirName) {
 		return true
 	}
 	return false
 }
 
+/*
+*
+*	Add the directory to gopath
+ */
 func addToGoPath(appDirName string) {
 	gopath := os.Getenv("GOPATH")
 	Log.Debugln("Current GoPath is ", gopath)

--- a/internal/root.go
+++ b/internal/root.go
@@ -13,10 +13,13 @@ import (
 
 var (
 	userLicense string
-	Log         *logrus.Logger
-	VERSION     string
+	// Log  is a logger from Sirupsen produced logrus
+	Log *logrus.Logger
+	// VERSION of application
+	VERSION string
 )
 
+// RootCmd is the rootcommand of the gokul application
 var RootCmd = &cobra.Command{
 	Use:   "gokul",
 	Short: "gokul is used to generate stubs for web application , deploy the application , run the application.",

--- a/pkg/server/apptempl/apptempl.go
+++ b/pkg/server/apptempl/apptempl.go
@@ -1,12 +1,13 @@
-package appTemplates
+package apptempl
 
 import (
 	"bytes"
-	"github.com/vipulbhale/gokul/pkg/server/util"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
+
+	"github.com/vipulbhale/gokul/pkg/server/util"
 
 	"github.com/sirupsen/logrus"
 )
@@ -14,6 +15,7 @@ import (
 var tpl bytes.Buffer
 var log *logrus.Logger
 
+// ApplicationForTemplate is a structure that represents application template object
 type ApplicationForTemplate struct {
 	AppNameForTemplate string
 	ParentAppDirectory string
@@ -54,8 +56,8 @@ import (
 	"fmt" 
 	"github.com/vipulbhale/gokul/pkg/server"
 	"github.com/vipulbhale/gokul/pkg/server/config"
-	"github.com/{{.AppNameForTemplate}}/controller"
-	"github.com/{{.AppNameForTemplate}}/util"
+	"github.com/{{.AppNameForTemplate}}/internal/controller"
+	"github.com/{{.AppNameForTemplate}}/internal/util"
 	"github.com/sirupsen/logrus"
 )
 
@@ -83,8 +85,8 @@ const CONTROLLER_TEMPLATE = `package controller
 
 import (
 	controller2 "github.com/vipulbhale/gokul/pkg/server/controller"
-	"github.com/{{.AppNameForTemplate}}/util"
-	"github.com/{{.AppNameForTemplate}}/service"
+	"github.com/{{.AppNameForTemplate}}/internal/util"
+	"github.com/{{.AppNameForTemplate}}/internal/service"
 	"github.com/sirupsen/logrus"
 )
 var Log         *logrus.Logger
@@ -136,8 +138,8 @@ func (d *DemoController) DemoJson() (error, *controller2.ModelAndView) {
 `
 const SERVICE_TEMPLATE = `package service
 import ( 
-	"github.com/{{.AppNameForTemplate}}/model"
-	"github.com/{{.AppNameForTemplate}}/util"
+	"github.com/{{.AppNameForTemplate}}/internal/model"
+	"github.com/{{.AppNameForTemplate}}/internal/util"
 	"github.com/sirupsen/logrus"
 )
 
@@ -292,18 +294,18 @@ func init() {
 func CreateTemplates(dirname, appName, cfgFileLocation string) {
 	log.Debugln("Entering the CreateTemplates method.")
 
-	writeToFileUsingTemplate(filepath.Join(dirname, "src", appName,"cmd"), "main.go", appName, cfgFileLocation, MAIN_PACKAGE)
-	writeToFileUsingTemplate(filepath.Join(dirname, "src",  appName, "internal", "controller"), "controller.go", appName, cfgFileLocation, CONTROLLER_TEMPLATE)
-	writeToFileUsingTemplate(filepath.Join(dirname, "src",  appName, "internal","service"), "service.go", appName, cfgFileLocation, SERVICE_TEMPLATE)
-	writeToFileUsingTemplate(filepath.Join(dirname, "src",  appName, "internal","model"), "model.go", appName, cfgFileLocation, MODEL_TEMPLATE)
-	writeToFileContent(filepath.Join(dirname, "src", appName,"internal", "view", "view.html"), VIEW_TEMPLATE)
-	writeToFileUsingTemplate(filepath.Join(dirname, "src",  appName,"internal", "util"), "logger.go", appName, cfgFileLocation, UTIL_LOGGER_TEMPLATE)
-	writeToFileUsingTemplate(filepath.Join(dirname, "src",  appName,"internal", "config"), "server.yml", appName, cfgFileLocation, CONFIG_FILE_TEMPLATE)
-	writeToFileUsingTemplate(filepath.Join(dirname, "src", appName, "internal","config"), "routes.yml", appName, cfgFileLocation, ROUTES_YML_TEMPLATE)
-	writeToFileUsingTemplate(filepath.Join(dirname, "src",  appName), "variables.env", appName, cfgFileLocation, "GOPATH="+os.Getenv("GOPATH"))
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "cmd", appName), "main.go", appName, cfgFileLocation, MAIN_PACKAGE)
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "internal", "controller"), "controller.go", appName, cfgFileLocation, CONTROLLER_TEMPLATE)
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "internal", "service"), "service.go", appName, cfgFileLocation, SERVICE_TEMPLATE)
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "internal", "model"), "model.go", appName, cfgFileLocation, MODEL_TEMPLATE)
+	writeToFileContent(filepath.Join(dirname, "src", "github.com", appName, "internal", "view", "view.html"), VIEW_TEMPLATE)
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "internal", "util"), "logger.go", appName, cfgFileLocation, UTIL_LOGGER_TEMPLATE)
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "internal", "config"), "server.yml", appName, cfgFileLocation, CONFIG_FILE_TEMPLATE)
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName, "internal", "config"), "routes.yml", appName, cfgFileLocation, ROUTES_YML_TEMPLATE)
+	writeToFileUsingTemplate(filepath.Join(dirname, "src", "github.com", appName), "variables.env", appName, cfgFileLocation, "GOPATH="+os.Getenv("GOPATH"))
 
-	createBinAndPackageDirectory(filepath.Join(dirname, "bin"))
-	createBinAndPackageDirectory(filepath.Join(dirname, "pkg"))
+	// createBinAndPackageDirectory(filepath.Join(dirname, "bin"))
+	// createBinAndPackageDirectory(filepath.Join(dirname, "pkg"))
 	createBinAndPackageDirectory(filepath.Join("/", "var", "log", appName))
 }
 

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"fmt"
-	"github.com/vipulbhale/gokul/pkg/server/util"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/vipulbhale/gokul/pkg/server/util"
 
 	"github.com/sirupsen/logrus"
 


### PR DESCRIPTION
This PR addresses:
  - Modifying the gokul project structure.
  - Apptemplate is created as per new project structure recommended for
  go modules. Now all files except the main.go for app will be created
  in the internal/* package.
  - Modified the appTemplates package name as apptemplates.
  - Updated gitignore to ignore gokul.yaml file.
  - Updated go.mod.
  - Refactored few variable names for consistency.

This should fix the issue #48 